### PR TITLE
Task 3: Graph Visualization for Bidirectional Edges

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,8 @@
 
 import { addEdge, applyEdgeChanges, applyNodeChanges, ReactFlow } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useMemo } from "react";
+import { BidirectionalEdge } from "../components/BidirectionalEdge";
 import { convertDataToGraphNodesAndEdges } from "../core/data/data-converter";
 import { GraphFormatService } from "../core/graph-format.service";
 import { ReactFlowService } from "../core/react-flow.service";
@@ -33,11 +34,20 @@ const { nodes: initialNodes, edges: initialEdges } = reactFlowService.convertDat
 	layoutedData.c1Nodes,
 	layoutedData.c2Nodes,
 	layoutedData.edges,
+	layoutedData.bidirectionalPairs,
+	layoutedData.processed
 );
 
 export default function App() {
 	const [nodes, setNodes] = useState(initialNodes);
 	const [edges, setEdges] = useState(initialEdges);
+
+	const edgeTypes = useMemo(
+		() => ({
+			bidirectional: BidirectionalEdge,
+		}),
+		[]
+	);
 
 	const onNodesChange = useCallback(
 		(changes: any) => setNodes((nodesSnapshot) => applyNodeChanges(changes, nodesSnapshot)),
@@ -59,6 +69,7 @@ export default function App() {
 				edges={edges}
 				onNodesChange={onNodesChange}
 				onEdgesChange={onEdgesChange}
+				edgeTypes={edgeTypes}
 				onConnect={onConnect}
 				fitView
 				minZoom={0.1}

--- a/components/BidirectionalEdge.tsx
+++ b/components/BidirectionalEdge.tsx
@@ -1,0 +1,86 @@
+import { BaseEdge, EdgeLabelRenderer, EdgeProps, getBezierPath } from '@xyflow/react';
+
+export function BidirectionalEdge({
+	id,
+	sourceX,
+	sourceY,
+	targetX,
+	targetY,
+	sourcePosition,
+	targetPosition,
+	data,
+	style,
+	markerEnd,
+}: EdgeProps) {
+	const forwardLabel = data?.forwardLabel || '';
+	const backwardLabel = data?.backwardLabel || '';
+
+	const OFFSET = 25; // for spacing between curves
+
+	const getOffset = (multiplier: number) => {
+		const dx = targetX - sourceX;
+		const dy = targetY - sourceY;
+		const len = Math.sqrt(dx * dx + dy * dy) || 1; // Avoid division by zero
+		return {
+			x: (-dy / len) * OFFSET * multiplier,
+			y: (dx / len) * OFFSET * multiplier
+		};
+	};
+
+	const forwardOffset = getOffset(1);
+	const backwardOffset = getOffset(-1);
+
+	// Forward path (A → B, curved up)
+	const [forwardPath, forwardLabelX, forwardLabelY] = getBezierPath({
+		sourceX: sourceX + forwardOffset.x,
+		sourceY: sourceY + forwardOffset.y,
+		sourcePosition,
+		targetX: targetX + forwardOffset.x,
+		targetY: targetY + forwardOffset.y,
+		targetPosition,
+	});
+
+	// Backward path (B → A, curved down)
+	const [backwardPath, backwardLabelX, backwardLabelY] = getBezierPath({
+		sourceX: targetX + backwardOffset.x,
+		sourceY: targetY + backwardOffset.y,
+		sourcePosition: targetPosition,
+		targetX: sourceX + backwardOffset.x,
+		targetY: sourceY + backwardOffset.y,
+		targetPosition: sourcePosition,
+	});
+
+	const Label = ({ x, y, text }: { x: number; y: number; text: string }) => (
+		<div
+			style={{
+				position: 'absolute',
+				transform: `translate(-50%, -50%) translate(${x}px, ${y}px)`,
+				background: 'white',
+				padding: '4px 8px',
+				borderRadius: '4px',
+				border: '1px solid #e5e7eb',
+				boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+				fontSize: 12,
+				fontWeight: 500,
+				maxWidth: '200px',
+				textAlign: 'center',
+				pointerEvents: 'all',
+			}}
+			className="nodrag nopan"
+		>
+			{text}
+		</div>
+	);
+
+	return (
+		<>
+			<BaseEdge id={`${id}-forward`} path={forwardPath} style={style} markerEnd={markerEnd} />
+			<BaseEdge id={`${id}-backward`} path={backwardPath} style={style} markerEnd={markerEnd} />
+			
+			<EdgeLabelRenderer>
+				<Label x={forwardLabelX} y={forwardLabelY} text={forwardLabel as string} />
+				<Label x={backwardLabelX} y={backwardLabelY} text={backwardLabel as string} />
+			</EdgeLabelRenderer>
+		</>
+	);
+}

--- a/core/graph-format.service.ts
+++ b/core/graph-format.service.ts
@@ -67,6 +67,26 @@ export class GraphFormatService {
 			}
 		});
 
+		const edgeMap = new Map(allEdges.map(e => [`${e.source}-${e.target}`, e]));
+		const processed = new Set<string>();
+		const bidirectionalPairs: any[] = [];
+
+		allEdges.forEach(edge => {
+			if (processed.has(edge.id)) return;
+			const reverse = edgeMap.get(`${edge.target}-${edge.source}`);
+			if (reverse) {
+				bidirectionalPairs.push({
+					id: `bidirectional-${edge.source}-${edge.target}`,
+					source: edge.source,
+					target: edge.target,
+					forwardLabel: edge.label,
+					backwardLabel: reverse.label,
+				});
+				processed.add(edge.id);
+				processed.add(reverse.id);
+			}
+		});
+
 		// Calculate layout
 		dagre.layout(dagreGraph);
 
@@ -109,6 +129,8 @@ export class GraphFormatService {
 			c1Nodes: positionedC1Nodes,
 			c2Nodes: positionedC2Nodes,
 			edges: allEdges,
+			bidirectionalPairs: bidirectionalPairs,
+			processed: processed,
 		};
 	}
 }

--- a/core/react-flow.service.ts
+++ b/core/react-flow.service.ts
@@ -55,17 +55,18 @@ export class ReactFlowService {
 
 
 		const reactFlowEdges = [
-			...bidirectionalPairs.map((pair) => ({
-				id: pair.id,
-				source: pair.source,
-				target: pair.target,
-				type: 'bidirectional',
-				data: {
-					forwardLabel: pair.forwardLabel,
-					backwardLabel: pair.backwardLabel,
-				},
-				style: { stroke: '#059669', strokeWidth: 2 }, // Dark green for bidirectional edges
-			})),
+		...bidirectionalPairs.map((pair) => ({
+			id: pair.id,
+			source: pair.source,
+			target: pair.target,
+			type: 'bidirectional',
+			data: {
+				forwardLabel: pair.forwardLabel,
+				backwardLabel: pair.backwardLabel,
+			},
+			style: { stroke: '#059669', strokeWidth: 2 }, // Dark green for bidirectional edges
+			markerEnd: { type: 'arrowclosed', color: '#059669' },
+		})),
 			...edges
 				.filter(edge => !processed.has(edge.id))
 				.map((edge) => ({

--- a/core/react-flow.service.ts
+++ b/core/react-flow.service.ts
@@ -1,11 +1,14 @@
-import type { GraphNode, GraphEdge, C1Output, C2Subcategory } from './types';
+import type { GraphNode, GraphEdge, C1Output, C2Subcategory, BidirectionalPair } from './types';
 
 export class ReactFlowService {
+
 	convertDataToReactFlowDataTypes(
 		graphNodes: GraphNode[],
 		c1Nodes: C1Output[],
 		c2Nodes: C2Subcategory[],
-		edges: GraphEdge[]
+		edges: GraphEdge[],
+		bidirectionalPairs: BidirectionalPair[],
+		processed: Set<string>
 	) {
 		const reactFlowNodes = [
 			// Regular graph nodes
@@ -50,20 +53,36 @@ export class ReactFlowService {
 			}))
 		];
 
-		const reactFlowEdges = edges.map((edge) => ({
-			id: edge.id,
-			source: edge.source,
-			target: edge.target,
-			label: edge.label,
-			style: edge.label === 'contains'
-				? { stroke: '#9ca3af', strokeDasharray: '5,5', strokeWidth: 1 } // Dashed light gray for containment
-				: edge.id.startsWith('c2_relationship')
-				? { stroke: '#059669', strokeWidth: 2 } // Dark green for C2-C2 relationships
-				: edge.id.startsWith('cross_c1_c2_rel')
-				? { stroke: '#d97706', strokeWidth: 2 } // Dark orange for cross C1-C2 relationships
-				: { stroke: '#374151', strokeWidth: 1 }, // Dark gray for other edges
-			labelStyle: { fill: '#000', fontWeight: '500' },
-		}));
+
+		const reactFlowEdges = [
+			...bidirectionalPairs.map((pair) => ({
+				id: pair.id,
+				source: pair.source,
+				target: pair.target,
+				type: 'bidirectional',
+				data: {
+					forwardLabel: pair.forwardLabel,
+					backwardLabel: pair.backwardLabel,
+				},
+				style: { stroke: '#059669', strokeWidth: 2 }, // Dark green for bidirectional edges
+			})),
+			...edges
+				.filter(edge => !processed.has(edge.id))
+				.map((edge) => ({
+					id: edge.id,
+					source: edge.source,
+					target: edge.target,
+					label: edge.label,
+					style: edge.label === 'contains'
+						? { stroke: '#9ca3af', strokeDasharray: '5,5', strokeWidth: 1 } // Dashed light gray for containment
+						: edge.id.startsWith('c2_relationship')
+						? { stroke: '#059669', strokeWidth: 2 } // Dark green for C2-C2 relationships
+						: edge.id.startsWith('cross_c1_c2_rel')
+						? { stroke: '#d97706', strokeWidth: 2 } // Dark orange for cross C1-C2 relationships
+						: { stroke: '#374151', strokeWidth: 1 }, // Dark gray for other edges
+					labelStyle: { fill: '#000', fontWeight: '500' },
+				}))
+		];
 
 		return {
 			nodes: reactFlowNodes,

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -11,6 +11,15 @@ export interface GraphEdge {
 	label: string;
 }
 
+export interface BidirectionalPair {
+	id: string;
+	source: string;
+	target: string;
+	forwardLabel: string;
+	backwardLabel: string;
+	isBidirectional: boolean;
+}
+
 export interface C1Output {
 	id: string;
 	label: string;


### PR DESCRIPTION
# feat(graph): Implement custom rendering for bidirectional edges

### Problem
Dagre layout treats all connections as a Directed Acyclic Graph (DAG).  
However, in cases where **two nodes have bidirectional edges**, React Flow renders both edges along the same path causing overlapping labels

Why it's broken:
- ReactFlow draws both edges along nearly the same path by default
- Both edge labels render at the center of the edge
- They occupy the exact same x,y coordinates → overlap and become unreadable

Example:

<img width="1345" height="430" alt="problem" src="https://github.com/user-attachments/assets/67090421-bb6a-4b36-b86b-4d9eece74a82" />

Constraints to maintain:
- Edge type must remain curved (no “smoothstep” or alternative styles).
- Edge labels must always be visible and non-overlapping.
- Labels must stay aligned if nodes are moved.


##  Solution Overview

### Bidirectional Edge Detection
Efficiently detect and merge edge pairs that connect the same two nodes in opposite directions.

**Algorithm:**
1. Create a lookup table keyed by `"source-target"`.
2. Iterate through all edges once.
3. For each edge `(A → B)`:
   - Check if `(B → A)` exists in the table.
   - If found, form a **bidirectional pair** object containing both edges and labels.
   - Mark both as processed.
4. Remaining unpaired edges are treated as normal unidirectional edges.

### Custom Edge Rendering Component
Render bidirectional pairs using **two parallel curved Bezier edges** that maintain visual separation.

#### A. Calculate Perpendicular Offset
- Compute direction vector from `source` to `target`.
- Normalize and rotate by 90° to get the perpendicular offset vector.
- Scale offset to a fixed distance (≈ 25px). // offset maintains spacing between both curves 
- Apply +offset to the forward edge and −offset to the backward edge.

#### B. Generate Curved Paths
- Shift source and target points by their respective offsets.
- Use React Flow’s internal `getBezierPath()` to create both paths.
- Compute each curve’s midpoint for label placement.

#### C. Render Two Separate Edges
- Forward curve → arrow pointing to target.
- Backward curve → arrow pointing to source.

<img width="1302" height="381" alt="image" src="https://github.com/user-attachments/assets/a98aa2e3-8d7d-45aa-b533-e93d7c18c8fa" />