### PR TITLE
Hierarchical layout + cleaner graph (Dagre + React Flow) by Shlok Kulkarni

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { addEdge, applyEdgeChanges, applyNodeChanges, ReactFlow } from "@xyflow/react";
+import { addEdge, applyEdgeChanges, applyNodeChanges, ReactFlow, Background, Controls, MiniMap } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useState } from "react";
 import { convertDataToGraphNodesAndEdges } from "../core/data/data-converter";
 import { GraphFormatService } from "../core/graph-format.service";
 import { ReactFlowService } from "../core/react-flow.service";
+import { nodeTypes } from "../components/react-flow-nodes";
 
 const graphFormatService = new GraphFormatService();
 const reactFlowService = new ReactFlowService();
@@ -20,12 +21,13 @@ const {
 } = convertDataToGraphNodesAndEdges();
 
 const layoutedData = graphFormatService.layoutCategoriesWithNodes(
-	graphNodes,
-	graphEdges,
-	c1Output,
-	c2Subcategories,
-	c2Relationships,
-	crossC1C2Relationships
+    graphNodes,
+    graphEdges,
+    c1Output,
+    c2Subcategories,
+    c2Relationships,
+    crossC1C2Relationships,
+    { rankdir: 'TB', nodesep: 70, ranksep: 140 }
 );
 
 const { nodes: initialNodes, edges: initialEdges } = reactFlowService.convertDataToReactFlowDataTypes(
@@ -60,11 +62,15 @@ export default function App() {
 				onNodesChange={onNodesChange}
 				onEdgesChange={onEdgesChange}
 				onConnect={onConnect}
+				nodeTypes={nodeTypes as any}
 				fitView
 				minZoom={0.1}
 				maxZoom={2}
 				style={{ background: "white" }}
 			/>
+			<Controls />
+			<MiniMap zoomable pannable />
+			<Background gap={24} />
 		</div>
 	);
 }

--- a/core/graph-format.service.ts
+++ b/core/graph-format.service.ts
@@ -1,15 +1,25 @@
 import dagre from 'dagre';
 import type { GraphNode, GraphEdge, C1Output, C2Subcategory, C2Relationship, CrossC1C2Relationship } from './types';
 
+type LayoutOptions = {
+    rankdir?: 'TB' | 'LR';
+    nodesep?: number;
+    ranksep?: number;
+    edgesep?: number;
+    marginx?: number;
+    marginy?: number;
+};
+
 export class GraphFormatService {
-	layoutCategoriesWithNodes(
-		graphNodes: GraphNode[],
-		graphEdges: GraphEdge[],
-		c1Outputs: C1Output[],
-		c2Subcategories: C2Subcategory[],
-		c2Relationships: C2Relationship[],
-		crossC1C2Relationships: CrossC1C2Relationship[]
-	) {
+    layoutCategoriesWithNodes(
+        graphNodes: GraphNode[],
+        graphEdges: GraphEdge[],
+        c1Outputs: C1Output[],
+        c2Subcategories: C2Subcategory[],
+        c2Relationships: C2Relationship[],
+        crossC1C2Relationships: CrossC1C2Relationship[],
+        options: LayoutOptions = {}
+    ) {
 		// Create a mapping from C2 names to C2 IDs for relationships
 		const c2NameToIdMap = new Map();
 		c2Subcategories.forEach(c2 => {
@@ -18,8 +28,15 @@ export class GraphFormatService {
 		const dagreGraph = new dagre.graphlib.Graph();
 		dagreGraph.setDefaultEdgeLabel(() => ({}));
 
-		// Set up the graph
-		dagreGraph.setGraph({ rankdir: 'TB' });
+        // Set up the graph with generous spacing and balanced ranks
+        dagreGraph.setGraph({
+            rankdir: options.rankdir ?? 'TB',
+            nodesep: options.nodesep ?? 60,
+            ranksep: options.ranksep ?? 120,
+            edgesep: options.edgesep ?? 20,
+            marginx: options.marginx ?? 40,
+            marginy: options.marginy ?? 40,
+        } as any);
 
 		// Add all nodes to dagre
 		const allNodes = [
@@ -29,9 +46,14 @@ export class GraphFormatService {
 		];
 
 
-		allNodes.forEach((node) => {
-			dagreGraph.setNode(node.id, { width: 150, height: 50 });
-		});
+        allNodes.forEach((node) => {
+            // Wider for categories for better visual balance
+            const isC1 = (node as any).type === 'c1';
+            const isC2 = (node as any).type === 'c2';
+            const width = isC1 ? 240 : isC2 ? 220 : 200;
+            const height = isC1 ? 80 : isC2 ? 70 : 60;
+            dagreGraph.setNode(node.id, { width, height });
+        });
 
 		// Add all edges to dagre
 		const allEdges: GraphEdge[] = [
@@ -53,7 +75,7 @@ export class GraphFormatService {
 				}))
 			),
 			// C2 relationships
-			...c2Relationships.map(rel => {
+            ...c2Relationships.map(rel => {
 				const sourceId = c2NameToIdMap.get(rel.fromC2);
 				const targetId = c2NameToIdMap.get(rel.toC2);
 				if (!sourceId || !targetId) {
@@ -61,14 +83,14 @@ export class GraphFormatService {
 					return null;
 				}
 				return {
-					id: rel.id,
+                    id: `c2_relationship_${rel.id}`,
 					source: sourceId,
 					target: targetId,
 					label: rel.label
 				};
 			}).filter((edge): edge is GraphEdge => edge !== null),
 			// Cross C1-C2 relationships (connect C2 nodes across different C1 categories)
-			...crossC1C2Relationships.map(rel => {
+            ...crossC1C2Relationships.map(rel => {
 				const sourceId = c2NameToIdMap.get(rel.fromC2);
 				const targetId = c2NameToIdMap.get(rel.toC2);
 				if (!sourceId || !targetId) {
@@ -76,7 +98,7 @@ export class GraphFormatService {
 					return null;
 				}
 				return {
-					id: rel.id,
+                    id: `cross_c1_c2_rel_${rel.id}`,
 					source: sourceId,
 					target: targetId,
 					label: rel.label
@@ -84,16 +106,21 @@ export class GraphFormatService {
 			}).filter((edge): edge is GraphEdge => edge !== null)
 		];
 
-		allEdges.forEach((edge) => {
-			if (edge) {
-				dagreGraph.setEdge(edge.source, edge.target);
-			}
-		});
+        // Prefer forward edges and penalize crossings by labeling containment with lower weight
+        allEdges.forEach((edge) => {
+            if (edge) {
+                const isContainment = edge.label === 'contains';
+                dagreGraph.setEdge(edge.source, edge.target, {
+                    weight: isContainment ? 3 : 1,
+                    minlen: isContainment ? 1 : 2,
+                });
+            }
+        });
 
 		// Calculate layout
 		dagre.layout(dagreGraph);
 
-		// Apply positions to all nodes
+        // Apply positions to all nodes with top-left anchoring used by React Flow
 		const positionedGraphNodes = graphNodes.map((node) => {
 			const nodeWithPosition = dagreGraph.node(node.id);
 			return {

--- a/core/react-flow.service.ts
+++ b/core/react-flow.service.ts
@@ -12,8 +12,8 @@ export class ReactFlowService {
 			...graphNodes.map((node) => ({
 				id: node.id,
 				position: node.position || { x: 0, y: 0 },
-				data: { label: node.label },
-				type: 'default',
+				data: { label: node.label, type: 'file' },
+				type: 'graphNode',
 				style: {
 					background: '#dbeafe',
 					border: '2px solid #3b82f6',
@@ -25,8 +25,8 @@ export class ReactFlowService {
 			...c1Nodes.map((node) => ({
 				id: node.id,
 				position: node.position || { x: 0, y: 0 },
-				data: { label: node.label },
-				type: 'default',
+				data: { label: node.label, categoryData: { c1Category: node.c1Category, nodesInCategory: node.nodesInCategory } },
+				type: 'c1CategoryNode',
 				style: {
 					background: '#fef2f2',
 					border: '3px solid #dc2626',
@@ -39,8 +39,8 @@ export class ReactFlowService {
 			...c2Nodes.map((node) => ({
 				id: node.id,
 				position: node.position || { x: 0, y: 0 },
-				data: { label: node.label },
-				type: 'default',
+				data: { label: node.label, categoryData: { c2Name: node.c2Name, nodeCount: node.nodeCount } },
+				type: 'c2SubcategoryNode',
 				style: {
 					background: '#f0fdf4',
 					border: '2px solid #16a34a',

--- a/core/types/index.ts
+++ b/core/types/index.ts
@@ -48,3 +48,26 @@ export interface CrossC1C2Relationship {
 	toC2: string;
 	label: string;
 }
+
+// Minimal shape for React Flow nodes used by custom components
+export interface ReactFlowNode {
+  id: string;
+  position: { x: number; y: number };
+  type?: string;
+  data: {
+    label: string;
+    type?: string;
+    syntaxType?: string;
+    filePath?: string;
+    isAbstract?: boolean;
+    isOverride?: boolean;
+    categoryData?: {
+      c1Category?: string;
+      c2Name?: string;
+      nodesInCategory?: number;
+      nodeCount?: number;
+      categoryDescription?: string;
+      description?: string;
+    };
+  };
+}


### PR DESCRIPTION
**I reworked the graph layout so it’s easier to scan on larger projects. The old view felt cramped and noisy; this spreads ranks, cuts crossings, and makes categories/subcategories stand out**.

**What changed ?**

Hierarchical layout (Dagre) with tuned spacing
Larger C1/C2 nodes; clearer labels/counts
React Flow MiniMap/Controls/grid
Layout options exposed (rankdir, nodesep, ranksep)

**Why?**

You should be able to trace relationships in a few seconds without fighting overlaps.
Files :
core/graph-format.service.ts
core/react-flow.service.ts
core/types/index.ts
app/page.tsx
Testing
Loaded sample data, verified C1 → C2 → nodes order, checked edge labels/IDs, zoom/pan/fitView.
Notes
Defaults are for readability. If you want LR layout or different spacing, I can tweak quickly. Next up: edge routing, simple settings, cluster hulls.